### PR TITLE
Replace "tutorialspoint" with "ExtendsClass" in /misc/sandboxes

### DIFF
--- a/misc/sandboxes/mysql.html
+++ b/misc/sandboxes/mysql.html
@@ -3,6 +3,6 @@
 <p>Some useful online sandboxes for testing queries can be found below: <br>
   <a rel="noopener" target="_blank" href="http://sqlfiddle.com/#!9">http://sqlfiddle.com/</a> <br>
   <a rel="noopener" target="_blank" href="http://rextester.com/l/mysql_online_compiler">http://rextester.com/l/mysql_online_compiler</a> <br>
-  <a rel="noopener" target="_blank" href="https://www.tutorialspoint.com/mysql_terminal_online.php">https://www.tutorialspoint.com/mysql_terminal_online.php</a> <br>
+  <a rel="noopener" target="_blank" href="https://extendsclass.com/mysql-online.html">https://extendsclass.com/mysql-online.html</a> <br>
   <a rel="noopener" target="_blank" href="https://www.jdoodle.com/online-mysql-terminal">https://www.jdoodle.com/online-mysql-terminal</a>
 </p>


### PR DESCRIPTION
Hello, I replaced "tutorialspoint" with "ExtendsClass" in /misc/sandboxes.
The Tutorialspoint MySQL sandbox no longer exists.